### PR TITLE
Add PancakeSwap V3 deploy script for V3Utils and automators

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,93 @@ needs to be changed to
 
 bytes32 internal constant POOL_INIT_CODE_HASH = 0xe34f199b19b2b4f47f68442619d555527d244f78a3297ea89325f843f87b8b54;
 
+## Deployment for PancakeSwap (V3Utils + Automators)
+
+This repo includes `script/DeployPancakeV3UtilsAndAutomators.s.sol`, based on the PancakeSwap deployment flow from `v3utils`.
+
+It deploys:
+- `V3Utils`
+- `AutoRange`
+- `AutoCompound`
+- `AutoExit`
+
+Supported chains:
+- `1` (Ethereum mainnet)
+- `42161` (Arbitrum)
+- `8453` (Base)
+
+### Defaults used by the script
+
+The script has built-in defaults for Pancake and infra addresses:
+- Pancake NPM: `0x46A15B0b27311cedF172AB29E4f4766fbE7F4364`
+- Permit2: `0x000000000022D473030F116dDEE9F6B43aC78BA3`
+- 0x Allowance Holder: `0x0000000000001fF3684f28c67538d4D072C22734`
+- Universal Router:
+  - Mainnet: `0x66a9893cC07D91D95644AEDD05D03f95e1dBA8Af`
+  - Arbitrum: `0xA51afAFe0263b40EdaEf0Df8781eA9aa03E381a3`
+  - Base: `0x6fF5693b99212Da76ad316178A184AB56D299b43`
+
+Built-in role defaults:
+- Owner:
+  - Mainnet: `0xaac25e85e752425Dd1A92674CEeAF603758D3124`
+  - Arbitrum: `0x3e456ED2793988dc08f1482371b50bA2bC518175`
+  - Base: `0x45B220860A39f717Dc7daFF4fc08B69CB89d1cc9`
+- Operator: `0xae886c189a289be69Fb0249F2F0793d7B1E51ceB`
+- Withdrawer: `0x5663ba1B0B1d9b8559CFE049b33fe3B194852e82`
+
+`OWNER`, `OPERATOR`, and `WITHDRAWER` can still be overridden via env vars.
+
+### Optional overrides
+
+```sh
+export PANCAKE_NPM=0x...
+export UNIVERSAL_ROUTER=0x...
+export ZEROX_ALLOWANCE_HOLDER=0x...
+export PERMIT2=0x...
+
+export OWNER=0x...
+export OPERATOR=0x...
+export WITHDRAWER=0x...
+
+export TWAP_SECONDS=60
+export MAX_TWAP_TICK_DIFFERENCE=100
+```
+
+### Dry run (Ethereum mainnet)
+
+```sh
+ETH_RPC_URL="https://..." \
+PRIVATE_KEY="0xyour_private_key" \
+forge script script/DeployPancakeV3UtilsAndAutomators.s.sol:DeployPancakeV3UtilsAndAutomators \
+  --rpc-url "$ETH_RPC_URL" \
+  --private-key "$PRIVATE_KEY" \
+  -vvvv
+```
+
+### Broadcast
+
+```sh
+# Ethereum mainnet
+forge script script/DeployPancakeV3UtilsAndAutomators.s.sol:DeployPancakeV3UtilsAndAutomators \
+  --rpc-url "$MAINNET_RPC_URL" \
+  --private-key "$PRIVATE_KEY" \
+  --broadcast \
+  -vvvv
+
+# Arbitrum
+forge script script/DeployPancakeV3UtilsAndAutomators.s.sol:DeployPancakeV3UtilsAndAutomators \
+  --rpc-url "$ARBITRUM_RPC_URL" \
+  --private-key "$PRIVATE_KEY" \
+  --broadcast \
+  -vvvv
+
+# Base
+forge script script/DeployPancakeV3UtilsAndAutomators.s.sol:DeployPancakeV3UtilsAndAutomators \
+  --rpc-url "$BASE_RPC_URL" \
+  --private-key "$PRIVATE_KEY" \
+  --broadcast \
+  -vvvv
+```
+
+After broadcast, ownership transfer is initiated for all deployed `Ownable2Step` contracts.  
+The configured owner must call `acceptOwnership()` on each deployed contract.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,59 @@ Supported chains:
 - `42161` (Arbitrum)
 - `8453` (Base)
 
+### Special code changes for PancakeSwap (from `v3utils` README)
+
+These are the required code-level adaptations when syncing upstream Uniswap v3 libraries/interfaces for PancakeSwap compatibility.
+
+1. Update pool init code hash in `lib/v3-periphery/contracts/libraries/PoolAddress.sol`:
+
+```solidity
+bytes32 internal constant POOL_INIT_CODE_HASH = 0x6ce8eb472fa82df5469c6ab6d485f17c3ad13c8cd7af59b3d4a8026c5ce0f7e2;
+```
+
+2. Use `uint32 feeProtocol` in `slot0()` return type in `lib/v3-core/contracts/interfaces/pool/IUniswapV3PoolState.sol`:
+
+```solidity
+function slot0()
+    external
+    view
+    returns (
+        uint160 sqrtPriceX96,
+        int24 tick,
+        uint16 observationIndex,
+        uint16 observationCardinality,
+        uint16 observationCardinalityNext,
+        uint32 feeProtocol,
+        bool unlocked
+    );
+```
+
+3. Add `deployer()` to `lib/v3-periphery/contracts/interfaces/IPeripheryImmutableState.sol`:
+
+```solidity
+function deployer() external view returns (address);
+```
+
+4. Update `src/automators/Automator.sol` to use Pancake deployer for pool address computation:
+
+```solidity
+address private immutable deployer;
+```
+
+```solidity
+deployer = npm.deployer();
+```
+
+```solidity
+function _getPool(
+    address tokenA,
+    address tokenB,
+    uint24 fee
+) internal view returns (IUniswapV3Pool) {
+    return IUniswapV3Pool(PoolAddress.computeAddress(deployer, PoolAddress.getPoolKey(tokenA, tokenB, fee)));
+}
+```
+
 ### Defaults used by the script
 
 The script has built-in defaults for Pancake and infra addresses:

--- a/script/DeployPancakeV3UtilsAndAutomators.s.sol
+++ b/script/DeployPancakeV3UtilsAndAutomators.s.sol
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "forge-std/Script.sol";
+import "forge-std/console2.sol";
+
+import "v3-periphery/interfaces/INonfungiblePositionManager.sol";
+
+import "../src/transformers/V3Utils.sol";
+import "../src/transformers/AutoRange.sol";
+import "../src/transformers/AutoCompound.sol";
+import "../src/automators/AutoExit.sol";
+
+contract DeployPancakeV3UtilsAndAutomators is Script {
+    error UnsupportedChain(uint256 chainId);
+    error MissingContractCode(address target);
+    error InvalidTwapConfig(uint32 twapSeconds, uint16 maxTwapTickDifference);
+
+    uint256 internal constant MAINNET_CHAIN_ID = 1;
+    uint256 internal constant ARBITRUM_CHAIN_ID = 42161;
+    uint256 internal constant BASE_CHAIN_ID = 8453;
+
+    // PancakeSwap v3 addresses are the same on Ethereum, Arbitrum, and Base.
+    address internal constant DEFAULT_PANCAKE_FACTORY = 0x0BFbCF9fa4f9C56B0F40a671Ad40E0805A091865;
+    address internal constant DEFAULT_PANCAKE_NPM = 0x46A15B0b27311cedF172AB29E4f4766fbE7F4364;
+    address internal constant DEFAULT_PANCAKE_V3_SWAP_ROUTER = 0x1b81D678ffb9C0263b24A97847620C99d213eB14;
+
+    // Shared infra contracts across Ethereum, Arbitrum, and Base.
+    address internal constant DEFAULT_PERMIT2 = 0x000000000022D473030F116dDEE9F6B43aC78BA3;
+    address internal constant DEFAULT_ZEROX_ALLOWANCE_HOLDER = 0x0000000000001fF3684f28c67538d4D072C22734;
+
+    // Universal Router v2 defaults by chain (used by contracts when swapData is encoded in UR format).
+    address internal constant DEFAULT_UNIVERSAL_ROUTER_MAINNET = 0x66a9893cC07D91D95644AEDD05D03f95e1dBA8Af;
+    address internal constant DEFAULT_UNIVERSAL_ROUTER_ARBITRUM = 0xA51afAFe0263b40EdaEf0Df8781eA9aa03E381a3;
+    address internal constant DEFAULT_UNIVERSAL_ROUTER_BASE = 0x6fF5693b99212Da76ad316178A184AB56D299b43;
+
+    // Default ownership recipients by chain.
+    address internal constant DEFAULT_OWNER_MAINNET = 0xaac25e85e752425Dd1A92674CEeAF603758D3124;
+    address internal constant DEFAULT_OWNER_ARBITRUM = 0x3e456ED2793988dc08f1482371b50bA2bC518175;
+    address internal constant DEFAULT_OWNER_BASE = 0x45B220860A39f717Dc7daFF4fc08B69CB89d1cc9;
+    address internal constant DEFAULT_OPERATOR = 0xae886c189a289be69Fb0249F2F0793d7B1E51ceB;
+    address internal constant DEFAULT_WITHDRAWER = 0x5663ba1B0B1d9b8559CFE049b33fe3B194852e82;
+
+    struct DeployConfig {
+        INonfungiblePositionManager npm;
+        address universalRouter;
+        address zeroxAllowanceHolder;
+        address permit2;
+        address owner;
+        address operator;
+        address withdrawer;
+        uint32 twapSeconds;
+        uint16 maxTwapTickDifference;
+    }
+
+    function run()
+        external
+        returns (V3Utils v3Utils, AutoRange autoRange, AutoCompound autoCompound, AutoExit autoExit)
+    {
+        _assertSupportedChain(block.chainid);
+
+        DeployConfig memory config = _loadConfig();
+
+        vm.startBroadcast();
+
+        v3Utils = new V3Utils(
+            config.npm, config.universalRouter, config.zeroxAllowanceHolder, config.permit2
+        );
+        autoRange = new AutoRange(
+            config.npm,
+            config.operator,
+            config.withdrawer,
+            config.twapSeconds,
+            config.maxTwapTickDifference,
+            config.universalRouter,
+            config.zeroxAllowanceHolder
+        );
+        autoCompound = new AutoCompound(
+            config.npm, config.operator, config.withdrawer, config.twapSeconds, config.maxTwapTickDifference
+        );
+        autoExit = new AutoExit(
+            config.npm,
+            config.operator,
+            config.withdrawer,
+            config.twapSeconds,
+            config.maxTwapTickDifference,
+            config.universalRouter,
+            config.zeroxAllowanceHolder
+        );
+
+        // Ownable2Step contracts: set pending owner; OWNER must acceptOwnership() afterwards.
+        if (config.owner != tx.origin) {
+            v3Utils.transferOwnership(config.owner);
+            autoRange.transferOwnership(config.owner);
+            autoCompound.transferOwnership(config.owner);
+            autoExit.transferOwnership(config.owner);
+        }
+
+        vm.stopBroadcast();
+
+        console2.log("Network", _networkName(block.chainid));
+        console2.log("PancakeFactory", DEFAULT_PANCAKE_FACTORY);
+        console2.log("PancakeV3SwapRouter", DEFAULT_PANCAKE_V3_SWAP_ROUTER);
+        console2.log("PancakeNPM", address(config.npm));
+        console2.log("UniversalRouter", config.universalRouter);
+        console2.log("0xAllowanceHolder", config.zeroxAllowanceHolder);
+        console2.log("Permit2", config.permit2);
+        console2.log("Owner", config.owner);
+        console2.log("V3Utils", address(v3Utils));
+        console2.log("AutoRange", address(autoRange));
+        console2.log("AutoCompound", address(autoCompound));
+        console2.log("AutoExit", address(autoExit));
+    }
+
+    function _loadConfig() internal returns (DeployConfig memory config) {
+        address npmAddress = _envOrAddress("PANCAKE_NPM", DEFAULT_PANCAKE_NPM);
+        address universalRouterDefault = _defaultUniversalRouter(block.chainid);
+
+        config.npm = INonfungiblePositionManager(npmAddress);
+        config.universalRouter = _envOrAddress("UNIVERSAL_ROUTER", universalRouterDefault);
+        config.zeroxAllowanceHolder = _envOrAddress("ZEROX_ALLOWANCE_HOLDER", DEFAULT_ZEROX_ALLOWANCE_HOLDER);
+        config.permit2 = _envOrAddress("PERMIT2", DEFAULT_PERMIT2);
+        config.owner = _envOrAddress("OWNER", _defaultOwner(block.chainid));
+        config.operator = _envOrAddress("OPERATOR", DEFAULT_OPERATOR);
+        config.withdrawer = _envOrAddress("WITHDRAWER", DEFAULT_WITHDRAWER);
+        config.twapSeconds = uint32(_envOrUint("TWAP_SECONDS", 60));
+        config.maxTwapTickDifference = uint16(_envOrUint("MAX_TWAP_TICK_DIFFERENCE", 100));
+
+        if (config.twapSeconds < 60 || config.maxTwapTickDifference > 200) {
+            revert InvalidTwapConfig(config.twapSeconds, config.maxTwapTickDifference);
+        }
+
+        _assertContract(address(config.npm));
+        _assertContract(config.universalRouter);
+        _assertContract(config.zeroxAllowanceHolder);
+        _assertContract(config.permit2);
+    }
+
+    function _envOrAddress(string memory key, address defaultValue) internal returns (address value) {
+        try vm.envAddress(key) returns (address parsed) {
+            return parsed;
+        } catch {
+            return defaultValue;
+        }
+    }
+
+    function _envOrUint(string memory key, uint256 defaultValue) internal returns (uint256 value) {
+        try vm.envUint(key) returns (uint256 parsed) {
+            return parsed;
+        } catch {
+            return defaultValue;
+        }
+    }
+
+    function _defaultUniversalRouter(uint256 chainId) internal pure returns (address) {
+        if (chainId == MAINNET_CHAIN_ID) {
+            return DEFAULT_UNIVERSAL_ROUTER_MAINNET;
+        }
+        if (chainId == ARBITRUM_CHAIN_ID) {
+            return DEFAULT_UNIVERSAL_ROUTER_ARBITRUM;
+        }
+        if (chainId == BASE_CHAIN_ID) {
+            return DEFAULT_UNIVERSAL_ROUTER_BASE;
+        }
+        revert UnsupportedChain(chainId);
+    }
+
+    function _defaultOwner(uint256 chainId) internal pure returns (address) {
+        if (chainId == MAINNET_CHAIN_ID) {
+            return DEFAULT_OWNER_MAINNET;
+        }
+        if (chainId == ARBITRUM_CHAIN_ID) {
+            return DEFAULT_OWNER_ARBITRUM;
+        }
+        if (chainId == BASE_CHAIN_ID) {
+            return DEFAULT_OWNER_BASE;
+        }
+        revert UnsupportedChain(chainId);
+    }
+
+    function _assertSupportedChain(uint256 chainId) internal pure {
+        if (chainId != MAINNET_CHAIN_ID && chainId != ARBITRUM_CHAIN_ID && chainId != BASE_CHAIN_ID) {
+            revert UnsupportedChain(chainId);
+        }
+    }
+
+    function _assertContract(address target) internal view {
+        if (target.code.length == 0) {
+            revert MissingContractCode(target);
+        }
+    }
+
+    function _networkName(uint256 chainId) internal pure returns (string memory) {
+        if (chainId == MAINNET_CHAIN_ID) {
+            return "mainnet";
+        }
+        if (chainId == ARBITRUM_CHAIN_ID) {
+            return "arbitrum";
+        }
+        if (chainId == BASE_CHAIN_ID) {
+            return "base";
+        }
+        return "unsupported";
+    }
+}


### PR DESCRIPTION
## Summary
- add `DeployPancakeV3UtilsAndAutomators` forge script
- deploy `V3Utils`, `AutoRange`, `AutoCompound`, and `AutoExit`
- include PancakeSwap/Permit2/0x/Universal Router defaults for Ethereum, Arbitrum, and Base
- add chain-specific default owner addresses and default operator/withdrawer addresses
- transfer ownership for all Ownable2Step deployments (pending owner pattern)

## Validation
- forge build
