### PR TITLE
Audit fix: harden transform safety buffer checks

### DIFF
--- a/docs/agents/risk-and-acceptability.md
+++ b/docs/agents/risk-and-acceptability.md
@@ -11,13 +11,13 @@ Core health relation:
 Implementation details:
 
 - Collateral value uses oracle valuation and per-token collateral factors.
-- Vault uses an additional borrow safety buffer (`BORROW_SAFETY_BUFFER_X32 = 95%`) for debt-increasing operations.
+- Vault uses an additional borrow safety buffer (`BORROW_SAFETY_BUFFER_X32 = 95%`) for operations that worsen a loan's LTV / risk ratio.
 - Liquidation eligibility uses direct health (without borrow buffer).
 
 Practical implications:
 
 - A borrow can fail even before the position is strictly liquidatable.
-- During `transform()`, if debt did not increase, the borrow safety buffer is intentionally skipped. This allows legitimate position adjustments (range changes, compounding) near utilization boundaries. The full health check is still enforced — positions remain overcollateralized, just without the extra 5% margin. This is by design.
+- During `transform()`, the borrow safety buffer is intentionally skipped when the final loan LTV is unchanged or improved. This allows legitimate position adjustments (range changes, compounding, leverage adjustments that do not worsen LTV) near utilization boundaries. The full health check is still enforced — positions remain overcollateralized, just without the extra 5% margin. This is by design.
 
 ## 2) Liquidation Behavior
 

--- a/src/V3Vault.sol
+++ b/src/V3Vault.sol
@@ -591,7 +591,7 @@ contract V3Vault is ERC20, Multicall, Ownable2Step, IVault, IERC721Receiver, Con
                 revert CollateralFail();
             }
 
-            // Debt-neutral rescue transforms may bypass the borrow buffer only if they do not worsen the loan's LTV.
+            // Transforms may bypass the borrow buffer when they keep the loan's LTV unchanged or improve it.
             // If the final state is riskier than the starting point, it must still satisfy the buffered borrow check.
             if (_isRiskRatioWorse(oldDebt, oldCollateralValue, debt, newCollateralValue)) {
                 uint256 bufferedCollateralValue = newCollateralValue.mulDiv(BORROW_SAFETY_BUFFER_X32, Q32);

--- a/src/V3Vault.sol
+++ b/src/V3Vault.sol
@@ -521,12 +521,20 @@ contract V3Vault is ERC20, Multicall, Ownable2Step, IVault, IERC721Receiver, Con
         transformedTokenId = tokenId;
 
         (uint256 newDebtExchangeRateX96,) = _updateGlobalInterest();
+        uint256 oldDebtShares = loans[tokenId].debtShares;
+        uint256 oldDebt;
+        uint256 oldCollateralValue;
 
         address loanOwner = tokenOwner[tokenId];
 
         // only the owner of the loan or any approved caller can call this
         if (loanOwner != msg.sender && !transformApprovals[loanOwner][tokenId][msg.sender]) {
             revert Unauthorized();
+        }
+
+        if (oldDebtShares != 0) {
+            oldDebt = _convertToAssets(oldDebtShares, newDebtExchangeRateX96, Math.Rounding.Up);
+            (, , oldCollateralValue,) = _checkLoanIsHealthy(tokenId, oldDebt, false);
         }
 
         if (
@@ -570,13 +578,28 @@ contract V3Vault is ERC20, Multicall, Ownable2Step, IVault, IERC721Receiver, Con
             try nonfungiblePositionManager.approve(address(0), tokenId) {} catch {}
         }
 
-        uint256 debt = _convertToAssets(loans[newTokenId].debtShares, newDebtExchangeRateX96, Math.Rounding.Up);
+        uint256 newDebtShares = loans[newTokenId].debtShares;
+        uint256 debt = _convertToAssets(newDebtShares, newDebtExchangeRateX96, Math.Rounding.Up);
 
         if (wasStaked) {
             // Re-check health in the final staked custody state because staking realizes pre-stake fees.
             _stake(newTokenId);
         }
-        _requireLoanIsHealthy(newTokenId, debt);
+        if (debt != 0) {
+            (bool isHealthy,, uint256 newCollateralValue,) = _checkLoanIsHealthy(newTokenId, debt, false);
+            if (!isHealthy) {
+                revert CollateralFail();
+            }
+
+            // Debt-neutral rescue transforms may bypass the borrow buffer only if they do not worsen the loan's LTV.
+            // If the final state is riskier than the starting point, it must still satisfy the buffered borrow check.
+            if (_isRiskRatioWorse(oldDebt, oldCollateralValue, debt, newCollateralValue)) {
+                uint256 bufferedCollateralValue = newCollateralValue.mulDiv(BORROW_SAFETY_BUFFER_X32, Q32);
+                if (bufferedCollateralValue < debt) {
+                    revert CollateralFail();
+                }
+            }
+        }
 
         transformedTokenId = 0;
     }
@@ -628,7 +651,7 @@ contract V3Vault is ERC20, Multicall, Ownable2Step, IVault, IERC721Receiver, Con
 
         // only does check health here if not in transform mode
         if (!isTransformMode) {
-            _requireLoanIsHealthy(tokenId, debt);
+            _requireLoanIsHealthy(tokenId, debt, true);
         }
 
         // fails if not enough asset available
@@ -684,7 +707,7 @@ contract V3Vault is ERC20, Multicall, Ownable2Step, IVault, IERC721Receiver, Con
         }
 
         uint256 debt = _convertToAssets(loans[params.tokenId].debtShares, newDebtExchangeRateX96, Math.Rounding.Up);
-        _requireLoanIsHealthy(params.tokenId, debt);
+        _requireLoanIsHealthy(params.tokenId, debt, true);
 
         emit WithdrawCollateral(params.tokenId, owner, params.recipient, params.liquidity, amount0, amount1);
     }
@@ -1281,10 +1304,44 @@ contract V3Vault is ERC20, Multicall, Ownable2Step, IVault, IERC721Receiver, Con
         }
     }
 
-    function _requireLoanIsHealthy(uint256 tokenId, uint256 debt) internal view {
-        (bool isHealthy,,,) = _checkLoanIsHealthy(tokenId, debt, true);
+    function _requireLoanIsHealthy(uint256 tokenId, uint256 debt, bool withBuffer) internal view {
+        (bool isHealthy,,,) = _checkLoanIsHealthy(tokenId, debt, withBuffer);
         if (!isHealthy) {
             revert CollateralFail();
+        }
+    }
+
+    function _isRiskRatioWorse(uint256 oldDebt, uint256 oldCollateralValue, uint256 newDebt, uint256 newCollateralValue)
+        internal
+        pure
+        returns (bool)
+    {
+        if (newDebt == 0) {
+            return false;
+        }
+        if (oldDebt == 0) {
+            return true;
+        }
+        if (oldCollateralValue == 0) {
+            return false;
+        }
+        if (newCollateralValue == 0) {
+            return true;
+        }
+
+        (uint256 lhsHigh, uint256 lhsLow) = _mul512(newDebt, oldCollateralValue);
+        (uint256 rhsHigh, uint256 rhsLow) = _mul512(oldDebt, newCollateralValue);
+        if (lhsHigh != rhsHigh) {
+            return lhsHigh > rhsHigh;
+        }
+        return lhsLow > rhsLow;
+    }
+
+    function _mul512(uint256 a, uint256 b) internal pure returns (uint256 high, uint256 low) {
+        assembly ("memory-safe") {
+            let mm := mulmod(a, b, not(0))
+            low := mul(a, b)
+            high := sub(sub(mm, low), lt(mm, low))
         }
     }
 
@@ -1389,7 +1446,7 @@ contract V3Vault is ERC20, Multicall, Ownable2Step, IVault, IERC721Receiver, Con
         // healthy under the post-stake valuation model, which excludes fee collateral for staked positions.
         if (loans[tokenId].debtShares != 0) {
             (uint256 debt,,,,) = loanInfo(tokenId);
-            _requireLoanIsHealthy(tokenId, debt);
+            _requireLoanIsHealthy(tokenId, debt, true);
         }
     }
 

--- a/test/integration/aerodrome/V3VaultAerodrome.t.sol
+++ b/test/integration/aerodrome/V3VaultAerodrome.t.sol
@@ -17,6 +17,10 @@ contract MockLiquidityStripTransformer {
     }
 }
 
+contract NoopRewardCompoundTransformer {
+    function execute() external {}
+}
+
 contract V3VaultAerodromeTest is AerodromeTestBase {
     event DebugUint(string label, uint256 value);
 
@@ -161,6 +165,61 @@ contract V3VaultAerodromeTest is AerodromeTestBase {
 
         assertEq(gaugeManager.tokenIdToGauge(tokenId), address(usdcDaiGauge), "failed transform must leave stake intact");
         assertEq(npm.ownerOf(tokenId), address(usdcDaiGauge), "failed transform must revert NFT custody changes");
+    }
+
+    function testTransformWithRewardCompoundAllowsDebtNeutralAdjustmentAboveBorrowSafetyBuffer() public {
+        oracle.setMaxPoolPriceDifference(type(uint16).max);
+
+        NoopRewardCompoundTransformer transformer = new NoopRewardCompoundTransformer();
+        vault.setTransformer(address(transformer), true);
+
+        uint256 tokenId = createPositionProper(
+            alice,
+            address(usdc),
+            address(dai),
+            1,
+            -100,
+            100,
+            1e24,
+            0,
+            0
+        );
+
+        vm.startPrank(alice);
+        npm.approve(address(vault), tokenId);
+        vault.create(tokenId, alice);
+        vault.stakePosition(tokenId);
+
+        (, , uint256 collateralValue, ,) = vault.loanInfo(tokenId);
+        uint256 bufferedMax = collateralValue * uint256(vault.BORROW_SAFETY_BUFFER_X32()) / Q32;
+        vault.borrow(tokenId, bufferedMax - 1);
+
+        uint256 currentDebt;
+        uint256 currentCollateralValue;
+        bool crossedBorrowBuffer;
+        for (uint256 i; i < 100; ++i) {
+            vm.warp(block.timestamp + 1);
+            (currentDebt, , currentCollateralValue, ,) = vault.loanInfo(tokenId);
+            if (currentDebt > bufferedMax) {
+                crossedBorrowBuffer = true;
+                break;
+            }
+        }
+
+        assertTrue(crossedBorrowBuffer, "debt should cross the borrow buffer");
+        assertGt(currentDebt, bufferedMax, "debt should move above the borrow buffer");
+        assertLt(currentDebt, currentCollateralValue, "position should remain healthy without the buffer");
+
+        vault.approveTransform(tokenId, address(transformer), true);
+        uint256 returnedTokenId = vault.transformWithRewardCompound(
+            tokenId,
+            address(transformer),
+            abi.encodeCall(NoopRewardCompoundTransformer.execute, ()),
+            IVault.RewardCompoundParams(0, 5000, block.timestamp + 1)
+        );
+        vm.stopPrank();
+
+        assertEq(returnedTokenId, tokenId);
     }
 
     function testUnstakePosition() public {

--- a/test/integration/aerodrome/V3VaultTransformBorrowBuffer.t.sol
+++ b/test/integration/aerodrome/V3VaultTransformBorrowBuffer.t.sol
@@ -9,6 +9,22 @@ contract BorrowDuringTransformTransformer {
     }
 }
 
+contract NoopTransformBorrowBufferTransformer {
+    function execute() external {}
+}
+
+contract ReduceLiquidityTransformBorrowBufferTransformer {
+    MockAerodromePositionManager internal immutable npm;
+
+    constructor(MockAerodromePositionManager _npm) {
+        npm = _npm;
+    }
+
+    function execute(uint256 tokenId, uint128 newLiquidity) external {
+        npm.setLiquidity(tokenId, newLiquidity);
+    }
+}
+
 contract UnexpectedNFTSender {
     function push(MockAerodromePositionManager npm, address from, address to, uint256 tokenId) external {
         npm.safeTransferFrom(from, to, tokenId);
@@ -78,6 +94,8 @@ contract ReplacementDebtOverwriteAttacker {
 
 contract V3VaultTransformBorrowBufferTest is AerodromeTestBase {
     BorrowDuringTransformTransformer internal transformer;
+    NoopTransformBorrowBufferTransformer internal noopTransformer;
+    ReduceLiquidityTransformBorrowBufferTransformer internal reduceLiquidityTransformer;
     UnexpectedNFTTransferTransformer internal unexpectedNftTransformer;
     DirectNFTTransferTransformer internal directNftTransformer;
     TransformUnstakeExistingLoanTransformer internal unstakeExistingLoanTransformer;
@@ -87,6 +105,12 @@ contract V3VaultTransformBorrowBufferTest is AerodromeTestBase {
 
         transformer = new BorrowDuringTransformTransformer();
         vault.setTransformer(address(transformer), true);
+
+        noopTransformer = new NoopTransformBorrowBufferTransformer();
+        vault.setTransformer(address(noopTransformer), true);
+
+        reduceLiquidityTransformer = new ReduceLiquidityTransformBorrowBufferTransformer(npm);
+        vault.setTransformer(address(reduceLiquidityTransformer), true);
 
         unexpectedNftTransformer = new UnexpectedNFTTransferTransformer(npm);
         vault.setTransformer(address(unexpectedNftTransformer), true);
@@ -148,6 +172,113 @@ contract V3VaultTransformBorrowBufferTest is AerodromeTestBase {
             tokenId,
             address(transformer),
             abi.encodeCall(BorrowDuringTransformTransformer.execute, (address(vault), tokenId, amount))
+        );
+    }
+
+    function testTransformAllowsDebtNeutralAdjustmentAboveBorrowSafetyBuffer() external {
+        uint256 tokenId = createPositionProper(
+            alice,
+            address(usdc),
+            address(dai),
+            1,
+            -100,
+            100,
+            1e18,
+            50000e6,
+            50000e18
+        );
+
+        vm.prank(alice);
+        npm.approve(address(vault), tokenId);
+        vm.prank(alice);
+        vault.create(tokenId, alice);
+
+        (, , uint256 collateralValue, ,) = vault.loanInfo(tokenId);
+        uint256 bufferedMax = collateralValue * uint256(vault.BORROW_SAFETY_BUFFER_X32()) / Q32;
+        uint256 borrowAmount = bufferedMax - 1;
+
+        vm.prank(alice);
+        vault.borrow(tokenId, borrowAmount);
+
+        uint256 currentDebt;
+        uint256 currentCollateralValue;
+        bool crossedBorrowBuffer;
+        for (uint256 i; i < 100; ++i) {
+            vm.warp(block.timestamp + 1);
+            (currentDebt, , currentCollateralValue, ,) = vault.loanInfo(tokenId);
+            if (currentDebt > bufferedMax) {
+                crossedBorrowBuffer = true;
+                break;
+            }
+        }
+
+        assertTrue(crossedBorrowBuffer, "debt should cross the borrow buffer");
+        assertGt(currentDebt, bufferedMax, "debt should move above the borrow buffer");
+        assertLt(currentDebt, currentCollateralValue, "position should remain healthy without the buffer");
+
+        vm.prank(alice);
+        vault.approveTransform(tokenId, address(noopTransformer), true);
+
+        vm.prank(alice);
+        uint256 returnedTokenId =
+            vault.transform(tokenId, address(noopTransformer), abi.encodeCall(NoopTransformBorrowBufferTransformer.execute, ()));
+
+        assertEq(returnedTokenId, tokenId);
+        (uint256 debtAfter, , uint256 collateralValueAfter, ,) = vault.loanInfo(tokenId);
+        assertEq(debtAfter, currentDebt);
+        assertEq(collateralValueAfter, currentCollateralValue);
+    }
+
+    function testTransformCannotWorsenDebtNeutralLoanPastBorrowSafetyBuffer() external {
+        uint256 tokenId = createPositionProper(
+            alice,
+            address(usdc),
+            address(dai),
+            1,
+            -100,
+            100,
+            1e18,
+            50000e6,
+            50000e18
+        );
+
+        vm.prank(alice);
+        npm.approve(address(vault), tokenId);
+        vm.prank(alice);
+        vault.create(tokenId, alice);
+
+        (, , uint256 collateralValue, ,) = vault.loanInfo(tokenId);
+        uint256 bufferedMax = collateralValue * uint256(vault.BORROW_SAFETY_BUFFER_X32()) / Q32;
+        uint256 borrowAmount = bufferedMax - 1;
+
+        vm.prank(alice);
+        vault.borrow(tokenId, borrowAmount);
+
+        uint256 currentDebt;
+        uint256 currentCollateralValue;
+        bool crossedBorrowBuffer;
+        for (uint256 i; i < 100; ++i) {
+            vm.warp(block.timestamp + 1);
+            (currentDebt, , currentCollateralValue, ,) = vault.loanInfo(tokenId);
+            if (currentDebt > bufferedMax) {
+                crossedBorrowBuffer = true;
+                break;
+            }
+        }
+
+        assertTrue(crossedBorrowBuffer, "debt should cross the borrow buffer");
+        assertGt(currentDebt, bufferedMax, "debt should move above the borrow buffer");
+        assertLt(currentDebt, currentCollateralValue, "position should remain healthy without the buffer");
+
+        vm.prank(alice);
+        vault.approveTransform(tokenId, address(reduceLiquidityTransformer), true);
+
+        vm.prank(alice);
+        vm.expectRevert(Constants.CollateralFail.selector);
+        vault.transform(
+            tokenId,
+            address(reduceLiquidityTransformer),
+            abi.encodeCall(ReduceLiquidityTransformBorrowBufferTransformer.execute, (tokenId, uint128(999_900_000_000_000_000)))
         );
     }
 


### PR DESCRIPTION
## Summary
- restore explicit buffered vs unbuffered health checks
- allow debt-neutral transforms above the borrow safety buffer only when they do not worsen loan risk
- keep borrow, collateral-withdraw, and worsening transforms gated by the 95% buffer

## Testing
- forge test --match-path test/integration/aerodrome/V3VaultTransformBorrowBuffer.t.sol -vv
- forge test --match-path test/integration/aerodrome/V3VaultAerodrome.t.sol --match-test testTransformWithRewardCompoundAllowsDebtNeutralAdjustmentAboveBorrowSafetyBuffer -vv