### PR TITLE
Audit fix: harden collateral exposure limit checks

### DIFF
--- a/src/V3Vault.sol
+++ b/src/V3Vault.sol
@@ -170,6 +170,11 @@ contract V3Vault is ERC20, Multicall, Ownable2Step, IVault, IERC721Receiver, Con
     address public emergencyAdmin;
     address public gaugeManager;
 
+    // Transient slot tracking net shares minted earlier in the current transaction (deposits minus withdrawals).
+    // Borrow-side lender-base limits discount this value so temporary self-lending cannot relax risk caps.
+    uint256 private constant TX_SUPPLY_INFLATION_SHARES_SLOT =
+        0x77c5f5ad287ab5c7b7ea0aaa4c95632213a8f4eab414ff7bf7c4163f433cda41;
+
     constructor(
         string memory name,
         string memory symbol,
@@ -963,6 +968,7 @@ contract V3Vault is ERC20, Multicall, Ownable2Step, IVault, IERC721Receiver, Con
         _pullAssetFromSender(assets);
 
         _mint(receiver, shares);
+        _increaseTxSupplyInflation(shares);
 
         emit Deposit(msg.sender, receiver, assets, shares);
     }
@@ -995,6 +1001,7 @@ contract V3Vault is ERC20, Multicall, Ownable2Step, IVault, IERC721Receiver, Con
 
         // fails if not enough shares
         _burn(owner, shares);
+        _decreaseTxSupplyInflation(shares);
         SafeERC20.safeTransfer(IERC20(asset), receiver, assets);
 
         // when amounts are withdrawn - they may be deposited again
@@ -1058,6 +1065,46 @@ contract V3Vault is ERC20, Multicall, Ownable2Step, IVault, IERC721Receiver, Con
             return;
         }
         SafeERC20.safeTransferFrom(IERC20(asset), msg.sender, address(this), assets);
+    }
+
+    function _increaseTxSupplyInflation(uint256 shares) internal {
+        if (shares == 0) {
+            return;
+        }
+
+        uint256 inflatedShares = _getTxSupplyInflationShares() + shares;
+        assembly ("memory-safe") {
+            tstore(TX_SUPPLY_INFLATION_SHARES_SLOT, inflatedShares)
+        }
+    }
+
+    function _decreaseTxSupplyInflation(uint256 shares) internal {
+        if (shares == 0) {
+            return;
+        }
+
+        uint256 inflatedShares = _getTxSupplyInflationShares();
+        uint256 updatedShares = shares >= inflatedShares ? 0 : inflatedShares - shares;
+        assembly ("memory-safe") {
+            tstore(TX_SUPPLY_INFLATION_SHARES_SLOT, updatedShares)
+        }
+    }
+
+    function _getTxSupplyInflationShares() internal view returns (uint256 inflatedShares) {
+        assembly ("memory-safe") {
+            inflatedShares := tload(TX_SUPPLY_INFLATION_SHARES_SLOT)
+        }
+    }
+
+    function _getBorrowLimitLentAssets(uint256 lendExchangeRateX96) internal view returns (uint256) {
+        uint256 effectiveTotalSupply = totalSupply();
+        uint256 txSupplyInflationShares = _getTxSupplyInflationShares();
+        if (txSupplyInflationShares >= effectiveTotalSupply) {
+            effectiveTotalSupply = 0;
+        } else {
+            effectiveTotalSupply = effectiveTotalSupply - txSupplyInflationShares;
+        }
+        return _convertToAssets(effectiveTotalSupply, lendExchangeRateX96, Math.Rounding.Up);
     }
 
     function _maxDepositAssets(uint256 lendExchangeRateX96) internal view returns (uint256) {
@@ -1311,7 +1358,7 @@ contract V3Vault is ERC20, Multicall, Ownable2Step, IVault, IERC721Receiver, Con
 
                 // check if current value of used collateral is more than allowed limit
                 // if collateral is decreased - never revert
-                uint256 lentAssets = _convertToAssets(totalSupply(), lendExchangeRateX96, Math.Rounding.Up);
+                uint256 lentAssets = _getBorrowLimitLentAssets(lendExchangeRateX96);
                 uint256 collateralValueLimitFactorX32 = tokenConfigs[token0].collateralValueLimitFactorX32;
                 if (
                     collateralValueLimitFactorX32 < type(uint32).max
@@ -1357,7 +1404,7 @@ contract V3Vault is ERC20, Multicall, Ownable2Step, IVault, IERC721Receiver, Con
         view
         returns (uint256)
     {
-        uint256 limit = _convertToAssets(totalSupply(), lendExchangeRateX96, Math.Rounding.Up) * limitFactorX32 / Q32;
+        uint256 limit = _getBorrowLimitLentAssets(lendExchangeRateX96) * limitFactorX32 / Q32;
         return minLimit > limit ? minLimit : limit;
     }
 

--- a/test/integration/aerodrome/V3VaultCollateralLimit.t.sol
+++ b/test/integration/aerodrome/V3VaultCollateralLimit.t.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import "./AerodromeTestBase.sol";
+
+contract V3VaultCollateralLimitTest is AerodromeTestBase {
+    function setUp() public override {
+        super.setUp();
+
+        oracle.setMaxPoolPriceDifference(type(uint16).max);
+        vault.setLimits(0, 100_000_000, 100_000_000, 100_000_000, 100_000_000);
+
+        uint32 limitFactor = uint32(Q32 / 2);
+        vault.setTokenConfig(address(usdc), uint32(Q32 * 9 / 10), limitFactor);
+        vault.setTokenConfig(address(dai), uint32(Q32 * 9 / 10), limitFactor);
+
+        usdc.approve(address(vault), 10_000_000);
+        vault.deposit(10_000_000, address(this));
+    }
+
+    function testCollateralValueLimitCannotBeBypassedViaMulticallDepositSandwich() external {
+        uint256 tokenId = createPositionProper(
+            alice,
+            address(usdc),
+            address(dai),
+            1,
+            -100,
+            100,
+            1e18,
+            100e6,
+            100e18
+        );
+
+        vm.startPrank(alice);
+        npm.approve(address(vault), tokenId);
+        vault.create(tokenId, alice);
+
+        (, , uint256 collateralValue, ,) = vault.loanInfo(tokenId);
+        uint256 borrowAmount = 6_000_000;
+        assertGt(collateralValue, borrowAmount, "position should be healthy for the target borrow");
+
+        vm.expectRevert(Constants.CollateralValueLimit.selector);
+        vault.borrow(tokenId, borrowAmount);
+
+        uint256 flashDepositAmount = 50_000_000;
+        usdc.approve(address(vault), flashDepositAmount);
+
+        bytes[] memory calls = new bytes[](3);
+        calls[0] = abi.encodeCall(V3Vault.deposit, (flashDepositAmount, alice));
+        calls[1] = abi.encodeCall(V3Vault.borrow, (tokenId, borrowAmount));
+        calls[2] = abi.encodeCall(V3Vault.withdraw, (flashDepositAmount, alice, alice));
+
+        vm.expectRevert(Constants.CollateralValueLimit.selector);
+        vault.multicall(calls);
+        vm.stopPrank();
+
+        (uint256 debtShares) = vault.loans(tokenId);
+        assertEq(debtShares, 0, "bypass attempt must not leave residual debt");
+    }
+}

--- a/test/integration/uniswap/V3Vault.t.sol
+++ b/test/integration/uniswap/V3Vault.t.sol
@@ -1228,6 +1228,38 @@ contract V3VaultIntegrationTest is Test {
         assertEq(totalDebtShares, 0);
     }
 
+    function testCollateralValueLimitCannotBeBypassedViaMulticallDepositSandwich() external {
+        _setupBasicLoan(false);
+        vault.setTokenConfig(address(DAI), uint32(Q32 * 9 / 10), uint32(Q32 / 10)); // max 10% debt for DAI
+
+        vm.prank(TEST_NFT_ACCOUNT);
+        vault.borrow(TEST_NFT, 800000);
+
+        vm.expectRevert(Constants.CollateralValueLimit.selector);
+        vm.prank(TEST_NFT_ACCOUNT);
+        vault.borrow(TEST_NFT, 200001);
+
+        uint256 flashDepositAmount = 1_000_000;
+        vm.prank(WHALE_ACCOUNT);
+        USDC.transfer(TEST_NFT_ACCOUNT, flashDepositAmount);
+
+        vm.startPrank(TEST_NFT_ACCOUNT);
+        USDC.approve(address(vault), flashDepositAmount);
+
+        bytes[] memory calls = new bytes[](3);
+        calls[0] = abi.encodeCall(V3Vault.deposit, (flashDepositAmount, TEST_NFT_ACCOUNT));
+        calls[1] = abi.encodeCall(V3Vault.borrow, (TEST_NFT, 200001));
+        calls[2] = abi.encodeCall(V3Vault.withdraw, (flashDepositAmount, TEST_NFT_ACCOUNT, TEST_NFT_ACCOUNT));
+
+        vm.expectRevert(Constants.CollateralValueLimit.selector);
+        vault.multicall(calls);
+        vm.stopPrank();
+
+        (uint256 debtShares) = vault.loans(TEST_NFT);
+        assertEq(debtShares, 800000, "debt should remain at the pre-sandwich value");
+        assertEq(vault.balanceOf(TEST_NFT_ACCOUNT), 0, "flash deposit shares should not persist after revert");
+    }
+
     function testMainScenario() external {
         assertEq(vault.totalSupply(), 0);
         assertEq(vault.debtSharesTotal(), 0);


### PR DESCRIPTION
## Summary
- discount same-transaction share inflation when borrow-side lender-base limits read total supply
- close the multicall deposit/borrow/withdraw sandwich against per-token collateral caps
- add a fast Aerodrome regression and a matching Uniswap fork regression

## Testing
- forge test --match-path test/integration/aerodrome/V3VaultCollateralLimit.t.sol -vv
- Added coverage in test/integration/uniswap/V3Vault.t.sol, but could not run it locally because ANKR_API_KEY is not configured in this environment