### PR TITLE
Audit fix: use aerodrome router for base aerodrome flows

### DIFF
--- a/script/DeployAerodromeProtocol.s.sol
+++ b/script/DeployAerodromeProtocol.s.sol
@@ -29,7 +29,7 @@ contract DeployAerodromeProtocol is Script {
     address internal constant AERO = 0x940181a94A35A4569E4529A3CDfB74e38FD98631;
 
     // Routing infra
-    address internal constant UNIVERSAL_ROUTER = 0x198EF79F1F515F02dFE9e3115eD9fC07183f02fC;
+    address internal constant AERODROME_SWAP_ROUTER = 0x6Cb442acF35158D5eDa88fe602221b67B400Be3E;
     address internal constant ZEROX_ALLOWANCE_HOLDER = 0x0000000000001fF3684f28c67538d4D072C22734;
 
     // Chainlink feeds on Base
@@ -67,12 +67,13 @@ contract DeployAerodromeProtocol is Script {
         V3Vault vault = new V3Vault("Revert Lend USDC", "rlUSDC", USDC, npm, irm, oracle);
 
         GaugeManager gaugeManager =
-            new GaugeManager(npm, IERC20(AERO), IVault(address(vault)), UNIVERSAL_ROUTER, ZEROX_ALLOWANCE_HOLDER);
+            new GaugeManager(npm, IERC20(AERO), IVault(address(vault)), AERODROME_SWAP_ROUTER, ZEROX_ALLOWANCE_HOLDER);
         gaugeManager.setRewardBasePool(USDC, AERO_USDC_POOL);
         gaugeManager.setRewardBasePool(WETH, AERO_WETH_POOL);
         gaugeManager.setRewardBasePool(CBBTC, AERO_CBBTC_POOL);
 
-        LeverageTransformer leverageTransformer = new LeverageTransformer(npm, UNIVERSAL_ROUTER, ZEROX_ALLOWANCE_HOLDER);
+        LeverageTransformer leverageTransformer =
+            new LeverageTransformer(npm, AERODROME_SWAP_ROUTER, ZEROX_ALLOWANCE_HOLDER);
 
         AutoRangeAndCompound autoRange = new AutoRangeAndCompound(
             npm,
@@ -80,7 +81,7 @@ contract DeployAerodromeProtocol is Script {
             deployer, // withdrawer
             60, // TWAP seconds
             200, // max TWAP tick diff
-            UNIVERSAL_ROUTER,
+            AERODROME_SWAP_ROUTER,
             ZEROX_ALLOWANCE_HOLDER
         );
 
@@ -159,7 +160,7 @@ contract DeployAerodromeProtocol is Script {
         _requireCode(AERODROME_NPM, "DeployAerodromeProtocol: NPM missing code");
         _requireCode(AERODROME_FACTORY, "DeployAerodromeProtocol: factory missing code");
         _requireCode(AERODROME_GAUGE_FACTORY, "DeployAerodromeProtocol: gauge factory missing code");
-        _requireCode(UNIVERSAL_ROUTER, "DeployAerodromeProtocol: universal router missing code");
+        _requireCode(AERODROME_SWAP_ROUTER, "DeployAerodromeProtocol: aerodrome router missing code");
         _requireCode(ZEROX_ALLOWANCE_HOLDER, "DeployAerodromeProtocol: 0x allowance holder missing code");
         _requireCode(
             CHAINLINK_BASE_SEQUENCER_UPTIME_FEED, "DeployAerodromeProtocol: sequencer uptime feed missing code"

--- a/test/integration/base/BaseAerodromeIntegration.t.sol
+++ b/test/integration/base/BaseAerodromeIntegration.t.sol
@@ -51,6 +51,7 @@ contract BaseAerodromeIntegrationTest is Test, Constants {
     address constant WETH = 0x4200000000000000000000000000000000000006;
     address constant CBBTC = 0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf;
     address constant AERO = 0x940181a94A35A4569E4529A3CDfB74e38FD98631;
+    address constant AERODROME_SWAP_ROUTER = 0x6Cb442acF35158D5eDa88fe602221b67B400Be3E;
 
     INonfungiblePositionManager constant NPM = INonfungiblePositionManager(0x827922686190790b37229fd06084350E74485b72);
 
@@ -131,7 +132,7 @@ contract BaseAerodromeIntegrationTest is Test, Constants {
         gaugeManager.setRewardBasePool(CBBTC, aeroCbbtcPool);
         vault.setGaugeManager(address(gaugeManager));
 
-        autoRange = new AutoRangeAndCompound(NPM, OPERATOR, OPERATOR, 60, 200, address(0), address(0));
+        autoRange = new AutoRangeAndCompound(NPM, OPERATOR, OPERATOR, 60, 200, AERODROME_SWAP_ROUTER, address(0));
         autoRange.setVault(address(vault));
         vault.setTransformer(address(autoRange), true);
 

--- a/test/integration/base/V3UtilsAerodromeFork.t.sol
+++ b/test/integration/base/V3UtilsAerodromeFork.t.sol
@@ -15,7 +15,7 @@ contract V3UtilsAerodromeForkTest is Test, Constants {
     INonfungiblePositionManager constant NPM = INonfungiblePositionManager(0x827922686190790b37229fd06084350E74485b72);
     IAerodromeSlipstreamFactory constant FACTORY =
         IAerodromeSlipstreamFactory(0x5e7BB104d84c7CB9B682AaC2F3d509f5F406809A);
-    address constant UNIVERSAL_ROUTER = 0x198EF79F1F515F02dFE9e3115eD9fC07183f02fC;
+    address constant AERODROME_SWAP_ROUTER = 0x6Cb442acF35158D5eDa88fe602221b67B400Be3E;
 
     V3Utils internal v3utils;
     address internal owner;
@@ -24,7 +24,7 @@ contract V3UtilsAerodromeForkTest is Test, Constants {
         uint256 forkId = vm.createFork(_baseRpc(), BASE_FORK_BLOCK);
         vm.selectFork(forkId);
 
-        v3utils = new V3Utils(NPM, UNIVERSAL_ROUTER, address(0));
+        v3utils = new V3Utils(NPM, AERODROME_SWAP_ROUTER, address(0));
         owner = NPM.ownerOf(TEST_NFT);
     }
 

--- a/test/integration/base/automators/AerodromeAutomatorTestBase.sol
+++ b/test/integration/base/automators/AerodromeAutomatorTestBase.sol
@@ -36,7 +36,7 @@ abstract contract AerodromeAutomatorTestBase is Test {
 
     // Base network infrastructure
     address EX0x = address(0); // 0x not available on Base yet, will need alternative
-    address UNIVERSAL_ROUTER = 0x198EF79F1F515F02dFE9e3115eD9fC07183f02fC; // Universal Router on Base
+    address AERODROME_SWAP_ROUTER = 0x6Cb442acF35158D5eDa88fe602221b67B400Be3E; // Aerodrome router on Base
 
     // For testing, we'll create positions dynamically rather than using existing ones
     // This gives us more control over the test conditions
@@ -81,6 +81,6 @@ abstract contract AerodromeAutomatorTestBase is Test {
         baseFork = vm.createFork(BASE_RPC);
         vm.selectFork(baseFork);
 
-        v3utils = new V3Utils(NPM, EX0x, UNIVERSAL_ROUTER);
+        v3utils = new V3Utils(NPM, AERODROME_SWAP_ROUTER, EX0x);
     }
 } 

--- a/test/integration/base/automators/AutoRangeAndCompoundAerodrome.t.sol
+++ b/test/integration/base/automators/AutoRangeAndCompoundAerodrome.t.sol
@@ -10,7 +10,7 @@ import "v3-periphery/interfaces/INonfungiblePositionManager.sol";
 contract AutoRangeAndCompoundAerodromeTest is Test, Constants {
     INonfungiblePositionManager internal constant NPM =
         INonfungiblePositionManager(0x827922686190790b37229fd06084350E74485b72);
-    address internal constant UNIVERSAL_ROUTER = 0x198EF79F1F515F02dFE9e3115eD9fC07183f02fC;
+    address internal constant AERODROME_SWAP_ROUTER = 0x6Cb442acF35158D5eDa88fe602221b67B400Be3E;
 
     address internal constant OPERATOR_ACCOUNT = address(0x1111);
     address internal constant WITHDRAWER_ACCOUNT = address(0x2222);
@@ -30,7 +30,8 @@ contract AutoRangeAndCompoundAerodromeTest is Test, Constants {
         baseFork = vm.createFork(baseRpc);
         vm.selectFork(baseFork);
 
-        autoRange = new AutoRangeAndCompound(NPM, OPERATOR_ACCOUNT, WITHDRAWER_ACCOUNT, 60, 100, UNIVERSAL_ROUTER, address(0));
+        autoRange =
+            new AutoRangeAndCompound(NPM, OPERATOR_ACCOUNT, WITHDRAWER_ACCOUNT, 60, 100, AERODROME_SWAP_ROUTER, address(0));
     }
 
     function testSetTWAPSeconds() external {
@@ -114,6 +115,7 @@ contract AutoRangeAndCompoundAerodromeTest is Test, Constants {
         assertEq(autoRange.maxTWAPTickDifference(), 100);
         assertTrue(autoRange.operators(OPERATOR_ACCOUNT));
         assertEq(autoRange.withdrawer(), WITHDRAWER_ACCOUNT);
+        assertEq(autoRange.universalRouter(), AERODROME_SWAP_ROUTER);
     }
 
     function _defaultConfig() internal pure returns (AutoRangeAndCompound.PositionConfig memory config) {

--- a/test/integration/base/automators/AutoRangeAndCompoundAerodromeComprehensive.t.sol
+++ b/test/integration/base/automators/AutoRangeAndCompoundAerodromeComprehensive.t.sol
@@ -21,7 +21,7 @@ contract AutoRangeAndCompoundAerodromeComprehensiveTest is Test, Constants {
     IAerodromeSlipstreamFactory constant FACTORY =
         IAerodromeSlipstreamFactory(0x5e7BB104d84c7CB9B682AaC2F3d509f5F406809A);
     INonfungiblePositionManager constant NPM = INonfungiblePositionManager(0x827922686190790b37229fd06084350E74485b72);
-    address constant UNIVERSAL_ROUTER = 0x198EF79F1F515F02dFE9e3115eD9fC07183f02fC;
+    address constant AERODROME_SWAP_ROUTER = 0x6Cb442acF35158D5eDa88fe602221b67B400Be3E;
 
     // Test accounts
     address constant OPERATOR_ACCOUNT = address(0x1111);
@@ -49,7 +49,9 @@ contract AutoRangeAndCompoundAerodromeComprehensiveTest is Test, Constants {
         vm.selectFork(baseFork);
 
         autoRange =
-            new AutoRangeAndCompound(NPM, OPERATOR_ACCOUNT, WITHDRAWER_ACCOUNT, 60, 100, UNIVERSAL_ROUTER, address(0));
+            new AutoRangeAndCompound(
+                NPM, OPERATOR_ACCOUNT, WITHDRAWER_ACCOUNT, 60, 100, AERODROME_SWAP_ROUTER, address(0)
+            );
 
         _loadPositionDetails();
     }
@@ -178,7 +180,9 @@ contract AutoRangeAndCompoundAerodromeComprehensiveTest is Test, Constants {
         vm.selectFork(historicalFork);
 
         AutoRangeAndCompound localAutoRange =
-            new AutoRangeAndCompound(NPM, OPERATOR_ACCOUNT, WITHDRAWER_ACCOUNT, 60, 100, UNIVERSAL_ROUTER, address(0));
+            new AutoRangeAndCompound(
+                NPM, OPERATOR_ACCOUNT, WITHDRAWER_ACCOUNT, 60, 100, AERODROME_SWAP_ROUTER, address(0)
+            );
 
         uint256 tokenId = HAPPY_PATH_TOKEN_ID;
         address owner = NPM.ownerOf(tokenId);


### PR DESCRIPTION
## Summary
- switch Base Aerodrome deployment wiring to the Aerodrome swap router
- align Base Aerodrome fork tests and automator harnesses with the same router config
- add a constructor assertion in the Base AutoRangeAndCompound config test

## Testing
- forge test --match-path test/integration/base/automators/AutoRangeAndCompoundAerodrome.t.sol -vv
- BASE_RPC_URL=https://mainnet.base.org forge test --match-path test/integration/base/V3UtilsAerodromeFork.t.sol -vv
- BASE_RPC_URL=https://mainnet.base.org forge test --match-path test/integration/base/BaseAerodromeIntegration.t.sol --match-test testBaseSetupSanity -vv