### PR TITLE
Audit fix: skip borrow buffer for transforms

### DIFF
--- a/docs/agents/risk-and-acceptability.md
+++ b/docs/agents/risk-and-acceptability.md
@@ -17,7 +17,7 @@ Implementation details:
 Practical implications:
 
 - A borrow can fail even before the position is strictly liquidatable.
-- During `transform()`, if debt did not increase, the borrow safety buffer is intentionally skipped. This allows legitimate position adjustments (range changes, compounding) near utilization boundaries. The full health check is still enforced — positions remain overcollateralized, just without the extra 5% margin. This is by design.
+- During `transform()`, the borrow safety buffer is intentionally skipped. This allows legitimate position adjustments (range changes, compounding, or other transform flows) near utilization boundaries. The full health check is still enforced — positions remain overcollateralized, just without the extra 5% margin. This is by design.
 
 ## 2) Liquidation Behavior
 
@@ -57,7 +57,7 @@ When oracle verification fails, valuation-gated operations are intentionally blo
 - If `oracle.getValue(...)` cannot produce a trusted value (for example `PriceDifferenceExceeded`, stale/invalid feed data, or sequencer safety checks), health checks revert.
 - As a result, new debt issuance is blocked (`borrow`, debt-increasing transform paths), and liquidation is also blocked until oracle checks pass again.
 - This is an explicit safety design choice to avoid issuing debt or executing liquidation with untrusted pricing.
-- Exception: debt-free transform paths may skip health/oracle checks (see `V3Vault._requireLoanIsHealthy` which only applies borrow buffer when debt increased).
+- Exception: debt-free transform paths may skip health/oracle checks because there is no outstanding debt to validate. Indebted transform paths still perform a direct health/oracle check, just without the borrow safety buffer.
 
 ## 3) Rate Accrual And Solvency Accounting
 

--- a/src/V3Vault.sol
+++ b/src/V3Vault.sol
@@ -576,7 +576,7 @@ contract V3Vault is ERC20, Multicall, Ownable2Step, IVault, IERC721Receiver, Con
             // Re-check health in the final staked custody state because staking realizes pre-stake fees.
             _stake(newTokenId);
         }
-        _requireLoanIsHealthy(newTokenId, debt);
+        _requireLoanIsHealthy(newTokenId, debt, false);
 
         transformedTokenId = 0;
     }
@@ -628,7 +628,7 @@ contract V3Vault is ERC20, Multicall, Ownable2Step, IVault, IERC721Receiver, Con
 
         // only does check health here if not in transform mode
         if (!isTransformMode) {
-            _requireLoanIsHealthy(tokenId, debt);
+            _requireLoanIsHealthy(tokenId, debt, true);
         }
 
         // fails if not enough asset available
@@ -684,7 +684,7 @@ contract V3Vault is ERC20, Multicall, Ownable2Step, IVault, IERC721Receiver, Con
         }
 
         uint256 debt = _convertToAssets(loans[params.tokenId].debtShares, newDebtExchangeRateX96, Math.Rounding.Up);
-        _requireLoanIsHealthy(params.tokenId, debt);
+        _requireLoanIsHealthy(params.tokenId, debt, true);
 
         emit WithdrawCollateral(params.tokenId, owner, params.recipient, params.liquidity, amount0, amount1);
     }
@@ -1281,8 +1281,8 @@ contract V3Vault is ERC20, Multicall, Ownable2Step, IVault, IERC721Receiver, Con
         }
     }
 
-    function _requireLoanIsHealthy(uint256 tokenId, uint256 debt) internal view {
-        (bool isHealthy,,,) = _checkLoanIsHealthy(tokenId, debt, true);
+    function _requireLoanIsHealthy(uint256 tokenId, uint256 debt, bool withBuffer) internal view {
+        (bool isHealthy,,,) = _checkLoanIsHealthy(tokenId, debt, withBuffer);
         if (!isHealthy) {
             revert CollateralFail();
         }
@@ -1389,7 +1389,7 @@ contract V3Vault is ERC20, Multicall, Ownable2Step, IVault, IERC721Receiver, Con
         // healthy under the post-stake valuation model, which excludes fee collateral for staked positions.
         if (loans[tokenId].debtShares != 0) {
             (uint256 debt,,,,) = loanInfo(tokenId);
-            _requireLoanIsHealthy(tokenId, debt);
+            _requireLoanIsHealthy(tokenId, debt, true);
         }
     }
 

--- a/test/integration/aerodrome/V3VaultAerodrome.t.sol
+++ b/test/integration/aerodrome/V3VaultAerodrome.t.sol
@@ -17,6 +17,10 @@ contract MockLiquidityStripTransformer {
     }
 }
 
+contract NoopAerodromeTransformer {
+    function execute() external {}
+}
+
 contract V3VaultAerodromeTest is AerodromeTestBase {
     event DebugUint(string label, uint256 value);
 
@@ -161,6 +165,65 @@ contract V3VaultAerodromeTest is AerodromeTestBase {
 
         assertEq(gaugeManager.tokenIdToGauge(tokenId), address(usdcDaiGauge), "failed transform must leave stake intact");
         assertEq(npm.ownerOf(tokenId), address(usdcDaiGauge), "failed transform must revert NFT custody changes");
+    }
+
+    function testTransformWithRewardCompoundAllowsHealthyPositionAboveBorrowSafetyBuffer() public {
+        oracle.setMaxPoolPriceDifference(type(uint16).max);
+
+        NoopAerodromeTransformer transformer = new NoopAerodromeTransformer();
+        vault.setTransformer(address(transformer), true);
+
+        uint256 tokenId = createPositionProper(
+            alice,
+            address(usdc),
+            address(dai),
+            1,
+            -100,
+            100,
+            1e18,
+            1000e6,
+            1000e18
+        );
+
+        vm.startPrank(alice);
+        npm.approve(address(vault), tokenId);
+        vault.create(tokenId, alice);
+        vault.stakePosition(tokenId);
+        (, , uint256 collateralValue, ,) = vault.loanInfo(tokenId);
+        uint256 maxBorrow = collateralValue * vault.BORROW_SAFETY_BUFFER_X32() / Q32;
+        vault.borrow(tokenId, maxBorrow);
+        vm.stopPrank();
+
+        uint256 currentDebt;
+        uint256 currentCollateralValue;
+        bool crossedBorrowBuffer;
+        for (uint256 i; i < 100; ++i) {
+            vm.warp(block.timestamp + 1);
+            (currentDebt, , currentCollateralValue, ,) = vault.loanInfo(tokenId);
+            if (currentDebt > maxBorrow) {
+                crossedBorrowBuffer = true;
+                break;
+            }
+        }
+
+        assertTrue(crossedBorrowBuffer, "debt should cross the borrow buffer");
+        assertLt(currentDebt, currentCollateralValue, "position should remain directly healthy");
+
+        vm.prank(alice);
+        vault.approveTransform(tokenId, address(transformer), true);
+
+        vm.prank(alice);
+        uint256 returnedTokenId = vault.transformWithRewardCompound(
+            tokenId,
+            address(transformer),
+            abi.encodeCall(NoopAerodromeTransformer.execute, ()),
+            IVault.RewardCompoundParams({minAeroReward: 0, aeroSplitBps: 5000, deadline: block.timestamp})
+        );
+
+        assertEq(returnedTokenId, tokenId);
+        (uint256 debtAfter, , uint256 collateralValueAfter, ,) = vault.loanInfo(tokenId);
+        assertEq(debtAfter, currentDebt);
+        assertEq(collateralValueAfter, currentCollateralValue);
     }
 
     function testUnstakePosition() public {

--- a/test/integration/aerodrome/V3VaultTransformBorrowBuffer.t.sol
+++ b/test/integration/aerodrome/V3VaultTransformBorrowBuffer.t.sol
@@ -9,6 +9,10 @@ contract BorrowDuringTransformTransformer {
     }
 }
 
+contract NoopTransformBorrowBufferTransformer {
+    function execute() external {}
+}
+
 contract UnexpectedNFTSender {
     function push(MockAerodromePositionManager npm, address from, address to, uint256 tokenId) external {
         npm.safeTransferFrom(from, to, tokenId);
@@ -78,6 +82,7 @@ contract ReplacementDebtOverwriteAttacker {
 
 contract V3VaultTransformBorrowBufferTest is AerodromeTestBase {
     BorrowDuringTransformTransformer internal transformer;
+    NoopTransformBorrowBufferTransformer internal noopTransformer;
     UnexpectedNFTTransferTransformer internal unexpectedNftTransformer;
     DirectNFTTransferTransformer internal directNftTransformer;
     TransformUnstakeExistingLoanTransformer internal unstakeExistingLoanTransformer;
@@ -87,6 +92,9 @@ contract V3VaultTransformBorrowBufferTest is AerodromeTestBase {
 
         transformer = new BorrowDuringTransformTransformer();
         vault.setTransformer(address(transformer), true);
+
+        noopTransformer = new NoopTransformBorrowBufferTransformer();
+        vault.setTransformer(address(noopTransformer), true);
 
         unexpectedNftTransformer = new UnexpectedNFTTransferTransformer(npm);
         vault.setTransformer(address(unexpectedNftTransformer), true);
@@ -107,7 +115,7 @@ contract V3VaultTransformBorrowBufferTest is AerodromeTestBase {
         vm.stopPrank();
     }
 
-    function testTransformBorrowCannotBypassBorrowSafetyBuffer() external {
+    function testTransformBorrowCanExceedBorrowSafetyBufferWhenStillHealthy() external {
         uint256 tokenId = createPositionProper(
             alice,
             address(usdc),
@@ -141,7 +149,42 @@ contract V3VaultTransformBorrowBufferTest is AerodromeTestBase {
         vm.expectRevert(Constants.CollateralFail.selector);
         vault.borrow(tokenId, amount);
 
-        // Transform-mode borrow used to bypass the buffer via the unbuffered end-of-transform health check.
+        // Transform-mode borrow is intentionally allowed to exceed the borrow buffer as long as the
+        // final loan remains directly healthy.
+        vm.prank(alice);
+        uint256 returnedTokenId = vault.transform(
+            tokenId,
+            address(transformer),
+            abi.encodeCall(BorrowDuringTransformTransformer.execute, (address(vault), tokenId, amount))
+        );
+
+        assertEq(returnedTokenId, tokenId);
+        (uint256 debtAfter, , uint256 collateralValueAfter, ,) = vault.loanInfo(tokenId);
+        assertGt(debtAfter, bufferedMax);
+        assertLt(debtAfter, collateralValueAfter);
+    }
+
+    function testTransformBorrowStillFailsWhenLoanWouldBeUnhealthy() external {
+        uint256 tokenId = createPositionProper(
+            alice,
+            address(usdc),
+            address(dai),
+            1,
+            -100,
+            100,
+            1e18,
+            50000e6,
+            50000e18
+        );
+
+        vm.prank(alice);
+        npm.approve(address(vault), tokenId);
+        vm.prank(alice);
+        vault.create(tokenId, alice);
+
+        (, , uint256 collateralValue, ,) = vault.loanInfo(tokenId);
+        uint256 amount = collateralValue + 1;
+
         vm.prank(alice);
         vm.expectRevert(Constants.CollateralFail.selector);
         vault.transform(
@@ -149,6 +192,60 @@ contract V3VaultTransformBorrowBufferTest is AerodromeTestBase {
             address(transformer),
             abi.encodeCall(BorrowDuringTransformTransformer.execute, (address(vault), tokenId, amount))
         );
+    }
+
+    function testTransformAllowsDebtNeutralAdjustmentAboveBorrowSafetyBuffer() external {
+        uint256 tokenId = createPositionProper(
+            alice,
+            address(usdc),
+            address(dai),
+            1,
+            -100,
+            100,
+            1e18,
+            50000e6,
+            50000e18
+        );
+
+        vm.prank(alice);
+        npm.approve(address(vault), tokenId);
+        vm.prank(alice);
+        vault.create(tokenId, alice);
+
+        (, , uint256 collateralValue, ,) = vault.loanInfo(tokenId);
+        uint256 bufferedMax = collateralValue * uint256(vault.BORROW_SAFETY_BUFFER_X32()) / Q32;
+        uint256 borrowAmount = bufferedMax - 1;
+
+        vm.prank(alice);
+        vault.borrow(tokenId, borrowAmount);
+
+        uint256 currentDebt;
+        uint256 currentCollateralValue;
+        bool crossedBorrowBuffer;
+        for (uint256 i; i < 100; ++i) {
+            vm.warp(block.timestamp + 1);
+            (currentDebt, , currentCollateralValue, ,) = vault.loanInfo(tokenId);
+            if (currentDebt > bufferedMax) {
+                crossedBorrowBuffer = true;
+                break;
+            }
+        }
+
+        assertTrue(crossedBorrowBuffer, "debt should cross the borrow buffer");
+        assertGt(currentDebt, bufferedMax, "debt should move above the borrow buffer");
+        assertLt(currentDebt, currentCollateralValue, "position should remain healthy without the buffer");
+
+        vm.prank(alice);
+        vault.approveTransform(tokenId, address(noopTransformer), true);
+
+        vm.prank(alice);
+        uint256 returnedTokenId =
+            vault.transform(tokenId, address(noopTransformer), abi.encodeCall(NoopTransformBorrowBufferTransformer.execute, ()));
+
+        assertEq(returnedTokenId, tokenId);
+        (uint256 debtAfter, , uint256 collateralValueAfter, ,) = vault.loanInfo(tokenId);
+        assertEq(debtAfter, currentDebt);
+        assertEq(collateralValueAfter, currentCollateralValue);
     }
 
     function testTransformAllowsMigrationWhenOperatorDiffersButMaintainsCustody() external {


### PR DESCRIPTION
## Summary
- make post-transform health checks use direct health without the 95% borrow buffer
- keep normal borrow, decrease-liquidity, and explicit stake checks buffer-gated
- add aerodrome regressions for healthy-above-buffer transform flows

## Testing
- forge test --match-path test/integration/aerodrome/V3VaultTransformBorrowBuffer.t.sol -vv
- forge test --match-path test/integration/aerodrome/V3VaultAerodrome.t.sol --match-test testTransformWithRewardCompoundAllowsHealthyPositionAboveBorrowSafetyBuffer -vv