### PR TITLE
Audit fix: harden collateral limit lender-base checks

### DIFF
--- a/src/V3Vault.sol
+++ b/src/V3Vault.sol
@@ -170,6 +170,11 @@ contract V3Vault is ERC20, Multicall, Ownable2Step, IVault, IERC721Receiver, Con
     address public emergencyAdmin;
     address public gaugeManager;
 
+    // Transient slot tracking net shares minted earlier in the current transaction (deposits minus withdrawals).
+    // Borrow-side lender-base limits discount this value so temporary self-lending cannot relax risk caps.
+    uint256 private constant TX_SUPPLY_INFLATION_SHARES_SLOT =
+        0x77c5f5ad287ab5c7b7ea0aaa4c95632213a8f4eab414ff7bf7c4163f433cda41;
+
     constructor(
         string memory name,
         string memory symbol,
@@ -963,6 +968,7 @@ contract V3Vault is ERC20, Multicall, Ownable2Step, IVault, IERC721Receiver, Con
         _pullAssetFromSender(assets);
 
         _mint(receiver, shares);
+        _increaseTxSupplyInflation(shares);
 
         emit Deposit(msg.sender, receiver, assets, shares);
     }
@@ -995,6 +1001,7 @@ contract V3Vault is ERC20, Multicall, Ownable2Step, IVault, IERC721Receiver, Con
 
         // fails if not enough shares
         _burn(owner, shares);
+        _decreaseTxSupplyInflation(shares);
         SafeERC20.safeTransfer(IERC20(asset), receiver, assets);
 
         // when amounts are withdrawn - they may be deposited again
@@ -1058,6 +1065,46 @@ contract V3Vault is ERC20, Multicall, Ownable2Step, IVault, IERC721Receiver, Con
             return;
         }
         SafeERC20.safeTransferFrom(IERC20(asset), msg.sender, address(this), assets);
+    }
+
+    function _increaseTxSupplyInflation(uint256 shares) internal {
+        if (shares == 0) {
+            return;
+        }
+
+        uint256 inflatedShares = _getTxSupplyInflationShares() + shares;
+        assembly ("memory-safe") {
+            tstore(TX_SUPPLY_INFLATION_SHARES_SLOT, inflatedShares)
+        }
+    }
+
+    function _decreaseTxSupplyInflation(uint256 shares) internal {
+        if (shares == 0) {
+            return;
+        }
+
+        uint256 inflatedShares = _getTxSupplyInflationShares();
+        uint256 updatedShares = shares >= inflatedShares ? 0 : inflatedShares - shares;
+        assembly ("memory-safe") {
+            tstore(TX_SUPPLY_INFLATION_SHARES_SLOT, updatedShares)
+        }
+    }
+
+    function _getTxSupplyInflationShares() internal view returns (uint256 inflatedShares) {
+        assembly ("memory-safe") {
+            inflatedShares := tload(TX_SUPPLY_INFLATION_SHARES_SLOT)
+        }
+    }
+
+    function _getBorrowLimitLentAssets(uint256 lendExchangeRateX96) internal view returns (uint256) {
+        uint256 effectiveTotalSupply = totalSupply();
+        uint256 txSupplyInflationShares = _getTxSupplyInflationShares();
+        if (txSupplyInflationShares >= effectiveTotalSupply) {
+            effectiveTotalSupply = 0;
+        } else {
+            effectiveTotalSupply = effectiveTotalSupply - txSupplyInflationShares;
+        }
+        return _convertToAssets(effectiveTotalSupply, lendExchangeRateX96, Math.Rounding.Up);
     }
 
     function _maxDepositAssets(uint256 lendExchangeRateX96) internal view returns (uint256) {
@@ -1209,8 +1256,9 @@ contract V3Vault is ERC20, Multicall, Ownable2Step, IVault, IERC721Receiver, Con
             missing = reserveCost - reserves;
 
             uint256 totalLent = _convertToAssets(totalSupply(), newLendExchangeRateX96, Math.Rounding.Up);
-            uint256 preHaircutDailyDebtCap =
-                _calculateDailyIncreaseLimit(newLendExchangeRateX96, dailyDebtIncreaseLimitMin, MAX_DAILY_DEBT_INCREASE_X32);
+            uint256 preHaircutDailyDebtCap = _calculateDailyIncreaseLimit(
+                newLendExchangeRateX96, dailyDebtIncreaseLimitMin, MAX_DAILY_DEBT_INCREASE_X32
+            );
 
             // this lines distribute missing amount and remove it from all lent amount proportionally
             newLendExchangeRateX96 = (totalLent - missing) * newLendExchangeRateX96 / totalLent;
@@ -1218,8 +1266,9 @@ contract V3Vault is ERC20, Multicall, Ownable2Step, IVault, IERC721Receiver, Con
 
             // A reserve socialization haircut reduces the lender base mid-day.
             // Rescale remaining daily debt headroom so it tracks the post-haircut cap while preserving already-used budget.
-            uint256 postHaircutDailyDebtCap =
-                _calculateDailyIncreaseLimit(newLendExchangeRateX96, dailyDebtIncreaseLimitMin, MAX_DAILY_DEBT_INCREASE_X32);
+            uint256 postHaircutDailyDebtCap = _calculateDailyIncreaseLimit(
+                newLendExchangeRateX96, dailyDebtIncreaseLimitMin, MAX_DAILY_DEBT_INCREASE_X32
+            );
             if (
                 dailyDebtIncreaseLimitLastReset == uint32(block.timestamp / 1 days)
                     && postHaircutDailyDebtCap < preHaircutDailyDebtCap
@@ -1311,7 +1360,7 @@ contract V3Vault is ERC20, Multicall, Ownable2Step, IVault, IERC721Receiver, Con
 
                 // check if current value of used collateral is more than allowed limit
                 // if collateral is decreased - never revert
-                uint256 lentAssets = _convertToAssets(totalSupply(), lendExchangeRateX96, Math.Rounding.Up);
+                uint256 lentAssets = _getBorrowLimitLentAssets(lendExchangeRateX96);
                 uint256 collateralValueLimitFactorX32 = tokenConfigs[token0].collateralValueLimitFactorX32;
                 if (
                     collateralValueLimitFactorX32 < type(uint32).max
@@ -1336,8 +1385,9 @@ contract V3Vault is ERC20, Multicall, Ownable2Step, IVault, IERC721Receiver, Con
         // daily lend limit reset handling
         uint32 time = uint32(block.timestamp / 1 days);
         if (force || time > dailyLendIncreaseLimitLastReset) {
-            dailyLendIncreaseLimitLeft =
-                _calculateDailyIncreaseLimit(newLendExchangeRateX96, dailyLendIncreaseLimitMin, MAX_DAILY_LEND_INCREASE_X32);
+            dailyLendIncreaseLimitLeft = _calculateDailyIncreaseLimit(
+                newLendExchangeRateX96, dailyLendIncreaseLimitMin, MAX_DAILY_LEND_INCREASE_X32
+            );
             dailyLendIncreaseLimitLastReset = time;
         }
     }
@@ -1346,8 +1396,9 @@ contract V3Vault is ERC20, Multicall, Ownable2Step, IVault, IERC721Receiver, Con
         // daily debt limit reset handling
         uint32 time = uint32(block.timestamp / 1 days);
         if (force || time > dailyDebtIncreaseLimitLastReset) {
-            dailyDebtIncreaseLimitLeft =
-                _calculateDailyIncreaseLimit(newLendExchangeRateX96, dailyDebtIncreaseLimitMin, MAX_DAILY_DEBT_INCREASE_X32);
+            dailyDebtIncreaseLimitLeft = _calculateDailyIncreaseLimit(
+                newLendExchangeRateX96, dailyDebtIncreaseLimitMin, MAX_DAILY_DEBT_INCREASE_X32
+            );
             dailyDebtIncreaseLimitLastReset = time;
         }
     }
@@ -1357,7 +1408,7 @@ contract V3Vault is ERC20, Multicall, Ownable2Step, IVault, IERC721Receiver, Con
         view
         returns (uint256)
     {
-        uint256 limit = _convertToAssets(totalSupply(), lendExchangeRateX96, Math.Rounding.Up) * limitFactorX32 / Q32;
+        uint256 limit = _getBorrowLimitLentAssets(lendExchangeRateX96) * limitFactorX32 / Q32;
         return minLimit > limit ? minLimit : limit;
     }
 

--- a/test/integration/aerodrome/V3VaultCollateralLimit.t.sol
+++ b/test/integration/aerodrome/V3VaultCollateralLimit.t.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import "./AerodromeTestBase.sol";
+
+contract V3VaultCollateralLimitTest is AerodromeTestBase {
+    function setUp() public override {
+        super.setUp();
+
+        oracle.setMaxPoolPriceDifference(type(uint16).max);
+        vault.setLimits(0, 100_000_000, 100_000_000, 100_000_000, 100_000_000);
+
+        uint32 limitFactor = uint32(Q32 / 2);
+        vault.setTokenConfig(address(usdc), uint32(Q32 * 9 / 10), limitFactor);
+        vault.setTokenConfig(address(dai), uint32(Q32 * 9 / 10), limitFactor);
+
+        usdc.approve(address(vault), 10_000_000);
+        vault.deposit(10_000_000, address(this));
+    }
+
+    function testCollateralValueLimitCannotBeBypassedViaMulticallDepositSandwich() external {
+        uint256 tokenId = createPositionProper(alice, address(usdc), address(dai), 1, -100, 100, 1e18, 100e6, 100e18);
+
+        vm.startPrank(alice);
+        npm.approve(address(vault), tokenId);
+        vault.create(tokenId, alice);
+
+        (,, uint256 collateralValue,,) = vault.loanInfo(tokenId);
+        uint256 borrowAmount = 6_000_000;
+        assertGt(collateralValue, borrowAmount, "position should be healthy for the target borrow");
+
+        vm.expectRevert(Constants.CollateralValueLimit.selector);
+        vault.borrow(tokenId, borrowAmount);
+
+        uint256 flashDepositAmount = 50_000_000;
+        usdc.approve(address(vault), flashDepositAmount);
+
+        bytes[] memory calls = new bytes[](3);
+        calls[0] = abi.encodeCall(V3Vault.deposit, (flashDepositAmount, alice));
+        calls[1] = abi.encodeCall(V3Vault.borrow, (tokenId, borrowAmount));
+        calls[2] = abi.encodeCall(V3Vault.withdraw, (flashDepositAmount, alice, alice));
+
+        vm.expectRevert(Constants.CollateralValueLimit.selector);
+        vault.multicall(calls);
+        vm.stopPrank();
+
+        (uint256 debtShares) = vault.loans(tokenId);
+        assertEq(debtShares, 0, "bypass attempt must not leave residual debt");
+    }
+}

--- a/test/integration/uniswap/V3VaultCollateralLimit.t.sol
+++ b/test/integration/uniswap/V3VaultCollateralLimit.t.sol
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+
+import "../../../src/InterestRateModel.sol";
+import "../../../src/V3Oracle.sol";
+import "../../../src/V3Vault.sol";
+import "../../../src/utils/Constants.sol";
+
+contract V3VaultCollateralLimitForkTest is Test {
+    uint256 constant Q32 = 2 ** 32;
+    uint256 constant Q64 = 2 ** 64;
+
+    address constant WHALE_ACCOUNT = 0xF977814e90dA44bFA03b6295A0616a897441aceC;
+
+    IERC20 constant USDC = IERC20(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48);
+    IERC20 constant DAI = IERC20(0x6B175474E89094C44Da98b954EedeAC495271d0F);
+    IERC20 constant WETH = IERC20(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
+
+    INonfungiblePositionManager constant NPM = INonfungiblePositionManager(0xC36442b4a4522E871399CD717aBDD847Ab11FE88);
+
+    address constant CHAINLINK_USDC_USD = 0x8fFfFfd4AfB6115b954Bd326cbe7B4BA576818f6;
+    address constant CHAINLINK_DAI_USD = 0xAed0c38402a5d19df6E4c03F4E2DceD6e29c1ee9;
+    address constant CHAINLINK_ETH_USD = 0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419;
+
+    address constant UNISWAP_DAI_USDC = 0x5777d92f208679DB4b9778590Fa3CAB3aC9e2168;
+    address constant UNISWAP_ETH_USDC = 0x88e6A0c2dDD26FEEb64F039a2c41296FcB3f5640;
+
+    address constant TEST_NFT_ACCOUNT = 0x3b8ccaa89FcD432f1334D35b10fF8547001Ce3e5;
+    uint256 constant TEST_NFT = 126;
+
+    V3Vault internal vault;
+    InterestRateModel internal interestRateModel;
+    V3Oracle internal oracle;
+
+    function setUp() external {
+        string memory rpc = string.concat("https://rpc.ankr.com/eth/", vm.envString("ANKR_API_KEY"));
+        vm.createSelectFork(rpc, 18521658);
+
+        interestRateModel = new InterestRateModel(0, Q64 * 5 / 100, Q64 * 109 / 100, Q64 * 80 / 100);
+
+        oracle = new V3Oracle(NPM, address(USDC), address(0));
+        oracle.setMaxPoolPriceDifference(200);
+        oracle.setTokenConfig(
+            address(USDC),
+            AggregatorV3Interface(CHAINLINK_USDC_USD),
+            3600 * 24 * 30,
+            IUniswapV3Pool(address(0)),
+            0,
+            V3Oracle.Mode.TWAP,
+            0
+        );
+        oracle.setTokenConfig(
+            address(DAI),
+            AggregatorV3Interface(CHAINLINK_DAI_USD),
+            3600 * 24 * 30,
+            IUniswapV3Pool(UNISWAP_DAI_USDC),
+            60,
+            V3Oracle.Mode.CHAINLINK_TWAP_VERIFY,
+            50000
+        );
+        oracle.setTokenConfig(
+            address(WETH),
+            AggregatorV3Interface(CHAINLINK_ETH_USD),
+            3600 * 24 * 30,
+            IUniswapV3Pool(UNISWAP_ETH_USDC),
+            60,
+            V3Oracle.Mode.CHAINLINK_TWAP_VERIFY,
+            50000
+        );
+
+        vault = new V3Vault("Revert Lend USDC", "rlUSDC", address(USDC), NPM, interestRateModel, oracle);
+
+        uint32 limitFactor = uint32(Q32 / 2);
+        vault.setTokenConfig(address(USDC), uint32(Q32 * 9 / 10), limitFactor);
+        vault.setTokenConfig(address(DAI), uint32(Q32 * 9 / 10), limitFactor);
+        vault.setTokenConfig(address(WETH), uint32(Q32 * 9 / 10), limitFactor);
+
+        vault.setLimits(0, 100_000_000, 100_000_000, 100_000_000, 100_000_000);
+        vault.setReserveFactor(0);
+
+        vm.prank(WHALE_ACCOUNT);
+        USDC.approve(address(vault), 10_000_000);
+        vm.prank(WHALE_ACCOUNT);
+        vault.deposit(10_000_000, WHALE_ACCOUNT);
+    }
+
+    function testCollateralValueLimitCannotBeBypassedViaMulticallDepositSandwich() external {
+        vm.prank(TEST_NFT_ACCOUNT);
+        NPM.approve(address(vault), TEST_NFT);
+        vm.prank(TEST_NFT_ACCOUNT);
+        vault.create(TEST_NFT, TEST_NFT_ACCOUNT);
+
+        (, uint256 fullValue, uint256 collateralValue,,) = vault.loanInfo(TEST_NFT);
+        assertGt(fullValue, 0);
+        assertGt(collateralValue, 6_000_000);
+
+        vm.expectRevert(Constants.CollateralValueLimit.selector);
+        vm.prank(TEST_NFT_ACCOUNT);
+        vault.borrow(TEST_NFT, 6_000_000);
+
+        uint256 flashDepositAmount = 50_000_000;
+        vm.prank(WHALE_ACCOUNT);
+        USDC.transfer(TEST_NFT_ACCOUNT, flashDepositAmount);
+
+        vm.startPrank(TEST_NFT_ACCOUNT);
+        USDC.approve(address(vault), flashDepositAmount);
+
+        bytes[] memory calls = new bytes[](3);
+        calls[0] = abi.encodeCall(V3Vault.deposit, (flashDepositAmount, TEST_NFT_ACCOUNT));
+        calls[1] = abi.encodeCall(V3Vault.borrow, (TEST_NFT, 6_000_000));
+        calls[2] = abi.encodeCall(V3Vault.withdraw, (flashDepositAmount, TEST_NFT_ACCOUNT, TEST_NFT_ACCOUNT));
+
+        vm.expectRevert(Constants.CollateralValueLimit.selector);
+        vault.multicall(calls);
+        vm.stopPrank();
+
+        (uint256 debtShares) = vault.loans(TEST_NFT);
+        assertEq(debtShares, 0, "bypass attempt must not leave residual debt");
+    }
+}


### PR DESCRIPTION
## Summary
- discount same-tx share inflation from borrow-side lender-base calculations
- prevent deposit/borrow/withdraw sandwiches from relaxing per-token collateral exposure limits
- add Aerodrome and mainnet-fork regressions covering the multicall bypass path

## Verification
- forge test --match-path test/integration/aerodrome/V3VaultCollateralLimit.t.sol -vv
- ANKR_API_KEY=... forge test --match-path test/integration/uniswap/V3VaultCollateralLimit.t.sol -vv --fork-url https://rpc.ankr.com/eth/$ANKR_API_KEY